### PR TITLE
added current scope to notice model

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -3,7 +3,7 @@ class NoticesController < ApplicationController
 
   # GET /notices
   def index
-    @notices = Notice.all
+    @notices = Notice.current
 
     render json: @notices
   end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,2 +1,3 @@
 class Notice < ApplicationRecord
+  scope :current, -> { where("start_date <= ? AND end_date >= ?",DateTime.now,DateTime.now)}
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,3 +1,3 @@
 class Notice < ApplicationRecord
-  scope :current, -> { where("start_date <= ? AND end_date >= ?",DateTime.now,DateTime.now)}
+  scope :current, -> { where("start_date <= ? AND end_date >= ?", DateTime.now, DateTime.now)}
 end

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -10,7 +10,7 @@ class NoticeTest < ActiveSupport::TestCase
     notice3 = Notice.create(start_date: Date. yesterday, end_date: 3.days.from_now) #good
     notice4 = Notice.create(start_date: 2.days.ago, end_date: Date.tomorrow) #good
 
-    assert_equals(Notice.current,[notice, notice2, notice3, notice4])
+    assert_equal(Notice.current,[notice, notice2, notice3, notice4])
   end
 
   test "current scope does not return reversed dates" do
@@ -18,20 +18,20 @@ class NoticeTest < ActiveSupport::TestCase
     notice1 = Notice.create(start_date: Date.tomorrow, end_date: Date.yesterday) #bad
     notice2 = Notice.create(start_date:5.days.from_now, end_date: Date.yesterday) #bad
 
-    assert_equals(Notice.current, nil)
+    assert_equal(Notice.current, [])
   end
 
   test "current scope does not return future dates" do
     notice = Notice.create(start_date: Date.tomorrow, end_date: 2.days.from_now)#bad
     notice2 = Notice.create(start_date: 4.days.from_now, end_date: 5.days.from_now) #bad
 
-    assert_equals(Notice.current, nil)
+    assert_equal(Notice.current, [])
   end
 
   test "current scope does not return old notices" do
     notice= Notice.create(start_date: 5.days.ago, end_date: Date.yesterday) #bad
     notice = Notice.create(start_date: 10.days.ago, end_date: 3.days.ago)
 
-    assert_equals(Notice.current, nil)
+    assert_equal(Notice.current, [])
   end
 end

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -18,7 +18,7 @@ class NoticeTest < ActiveSupport::TestCase
     notice1 = Notice.create(start_date: Date.tomorrow, end_date: Date.yesterday) #bad
     notice2 = Notice.create(start_date:5.days.from_now, end_date: Date.yesterday) #bad
 
-    assert_equals(Notice.cuerrent, nil)
+    assert_equals(Notice.current, nil)
   end
 
   test "current scope does not return future dates" do

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -1,7 +1,37 @@
-require 'test_helper'
+require './test/test_helper'
 
 class NoticeTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end
+  test "current scope returns correct days" do
+    notice = Notice.create(start_date: Date.yesterday, end_date: Date.tomorrow) #good
+    notice2 = Notice.create(start_date: Date.yesterday, end_date: 5.days.from_now) #good
+    notice3 = Notice.create(start_date: Date. yesterday, end_date: 3.days.from_now) #good
+    notice4 = Notice.create(start_date: 2.days.ago, end_date: Date.tomorrow) #good
+
+    assert_equals(Notice.current,[notice, notice2, notice3, notice4])
+  end
+
+  test "current scope does not return reversed dates" do
+    notice = Notice.create(start_date: 10.days.from_now, end_date: Date.yesterday) #bad
+    notice1 = Notice.create(start_date: Date.tomorrow, end_date: Date.yesterday) #bad
+    notice2 = Notice.create(start_date:5.days.from_now, end_date: Date.yesterday) #bad
+
+    assert_equals(Notice.cuerrent, nil)
+  end
+
+  test "current scope does not return future dates" do
+    notice = Notice.create(start_date: Date.tomorrow, end_date: 2.days.from_now)#bad
+    notice2 = Notice.create(start_date: 4.days.from_now, end_date: 5.days.from_now) #bad
+
+    assert_equals(Notice.current, nil)
+  end
+
+  test "current scope does not return old notices" do
+    notice= Notice.create(start_date: 5.days.ago, end_date: Date.yesterday) #bad
+    notice = Notice.create(start_date: 10.days.ago, end_date: 3.days.ago)
+
+    assert_equals(Notice.current, nil)
+  end
 end


### PR DESCRIPTION
This adds a current scope to the notice model. Current returns all of the notices that have a start_date before today's date and an end_date after today's date. The index in the notice controller calls Notice.current instead of Notice.all to pull all current notices. 