### PR TITLE
Securing the notice-service controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:2.4.2
+FROM ruby:2.5.1
 
 RUN apt-get update && apt-get install -qq -y build-essential nodejs wget postgresql-client --fix-missing --no-install-recommends
 
-ENV INSTALL_PATH /usr/src/app
+ENV INSTALL_PATH /usr/src/app/
 RUN mkdir -p $INSTALL_PATH
 
 WORKDIR $INSTALL_PATH

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 #Netflix Fast json API used to seriailize API responses
 gem 'fast_jsonapi', '~> 1.3'
 
+#Use the Yacs Auth library to secure NoticesController
+gem 'yacs-auth', git:"https://github.com/YACS-RCOS/yacs-auth.git", branch: 'master'
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/YACS-RCOS/yacs-auth.git
+  revision: 9208d020d290ebd055cecef99071ac35e6e04f46
+  branch: master
+  specs:
+    yacs-auth (0.1.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -145,6 +152,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  yacs-auth!
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,6 +1,8 @@
 class NoticesController < ApplicationController
   before_action :set_notice, only: [:show, :update, :destroy]
 
+  before_action :allow_access
+
   # GET /notices
   def index
     @notices = Notice.current
@@ -46,5 +48,11 @@ class NoticesController < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def notice_params
       params.require(:notice).permit(:message, :alert_type, :start_date, :end_date)
+    end
+
+    def allow_access
+      if session[:token].nil?
+        render json: {}, status: 401
+      end
     end
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,7 +1,7 @@
 class NoticesController < ApplicationController
   before_action :set_notice, only: [:show, :update, :destroy]
 
-  before_action :allow_access
+  before_action :require_token
 
   # GET /notices
   def index
@@ -50,7 +50,7 @@ class NoticesController < ApplicationController
       params.require(:notice).permit(:message, :alert_type, :start_date, :end_date)
     end
 
-    def allow_access
+    def require_token
       if session[:token].nil?
         render json: {}, status: 401
       end

--- a/config/initializers/yacs-auth.rb
+++ b/config/initializers/yacs-auth.rb
@@ -1,0 +1,6 @@
+Yacs::Auth.configure do |config|
+
+  config.secret = 'It_is_a_secret'
+  config.redis = Redis.new(host: 'redis', port: 6379)
+
+end


### PR DESCRIPTION
The controller will be secured so that only an admin can create, update or destroy a notice object. This uses the YACS::Auth library. 